### PR TITLE
Change CMAKE_CXX_STANDARD from 11 to 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(lattedock)
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(VERSION 0.5.89)
 set(AUTHOR "Michail Vourlakos, Smith Ar")
 set(EMAIL "mvourlakos@gmail.com, audoban@openmailbox.org")


### PR DESCRIPTION
I was getting the following error when trying to compile and install:
/home/mateus/Latte-Dock/app/iconitem.cpp: In member function ‘void Latte::IconItem::setSource(const QVariant&)’:
/home/mateus/Latte-Dock/app/iconitem.cpp:98:29: error: ‘make_unique’ is not a member of ‘std’
                 m_svgIcon = std::make_unique<Plasma::Svg>(this);

So, changing the CMAKE_CXX_STANDARD from 11 to 14 solved this, since make_unique is a C++14 feature.