### PR TITLE
Include necessary header file for std::abs

### DIFF
--- a/liblattedock/extras.h
+++ b/liblattedock/extras.h
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <numeric>
 #include <memory>
+#include <cmath>
 
 #if __GLIBCXX__ <= 20150623
 namespace std {


### PR DESCRIPTION
While compiling Latte-Dock, i got the following error:

/data/latte-dock/src/latte-dock-git/app/iconitem.cpp:393:46:   required from here
/data/latte-dock/src/latte-dock-git/app/../liblattedock/extras.h:69:20: error: call of overloaded ‘abs(double)’ is ambiguous
     return std::abs(x - y) < std::numeric_limits<T>::epsilon() *
     std::abs(x + y) * ulp

In order to solve this error, i have to include `cmath`.