### PR TITLE
Update INSTALLATION.md for Arch Linux

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -16,8 +16,8 @@ sudo apt install g++ cmake extra-cmake-modules qtdeclarative5-dev libqt5x11extra
 
 ```
 sudo add-apt-repository ppa:kubuntu-ppa/backports
-sudo apt update 
-sudo apt dist-upgrade 
+sudo apt update
+sudo apt dist-upgrade
 ```
 
 ### Kubuntu and KDE Neon
@@ -29,10 +29,8 @@ sudo apt install cmake extra-cmake-modules qtdeclarative5-dev libqt5x11extras5-d
 ### Arch Linux
 
 ```
-sudo pacman -Syy
-sudo pacman -S cmake extra-cmake-modules
-sudo pacman -S qt5-base qt5-declarative qt5-x11extras
-sudo pacman -S kiconthemes kdbusaddons kxmlgui kdeclarative plasma-framework plasma-desktop
+sudo pacman -Syu
+sudo pacman -S cmake extra-cmake-modules python plasma-framework plasma-desktop
 ```
 
 ### Building and Installing

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We recommend that you use at least **Plasma 5.8.0**
 
 - [Fedora Copr](https://copr.fedorainfracloud.org/coprs/hcooh/Latte-dock/)
 
-### ArchLinux
+### Arch Linux
 
 - [Arch Linux](https://www.archlinux.org/packages/?sort=&q=latte-dock)
 


### PR DESCRIPTION
On Arch Linux partial upgrades are not recommended/supported. 
See: https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported

So I changed `pacman -Syy` to `pacman -Syu`

Also removed the dependencies that are pulled in by `plasma-framework` and added `python`.
Without python (or python2) installed, the build fails.

Additionaly I removed some trailing whitespace and changed `ArchLinux` to `Arch Linux` in README.md.
That's the official way it is written I think. ;)