### PR TITLE
Add libkf5crash-dev dependency for Neon/Kubuntu

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -17,7 +17,7 @@ sudo apt dist-upgrade
 ### Kubuntu and KDE Neon
 
 ```
-sudo apt install cmake extra-cmake-modules qtdeclarative5-dev libqt5x11extras5-dev libkf5iconthemes-dev libkf5plasma-dev libkf5windowsystem-dev libkf5declarative-dev libkf5xmlgui-dev libkf5activities-dev build-essential libxcb-util-dev libkf5wayland-dev git gettext libkf5archive-dev libkf5notifications-dev libxcb-util0-dev libsm-dev
+sudo apt install cmake extra-cmake-modules qtdeclarative5-dev libqt5x11extras5-dev libkf5iconthemes-dev libkf5plasma-dev libkf5windowsystem-dev libkf5declarative-dev libkf5xmlgui-dev libkf5activities-dev build-essential libxcb-util-dev libkf5wayland-dev git gettext libkf5archive-dev libkf5notifications-dev libxcb-util0-dev libsm-dev libkf5crash-dev
 ```
 
 ### Arch Linux


### PR DESCRIPTION
The installation script can't find "KF5Crash". Installing the package libkf5crash-dev solved the problem.