### PR TITLE
Activate next task in group on shortcut

### DIFF
--- a/plasmoid/package/contents/ui/main.qml
+++ b/plasmoid/package/contents/ui/main.qml
@@ -1400,7 +1400,11 @@ Item {
             var task = tasks[i];
 
             if (task.itemIndex === confirmedIndex) {
-                task.activateTask();
+                if (task.isGroupParent) {
+                    task.activateNextTask();
+                } else {
+                    task.activateTask();
+                }
                 break;
             }
         }


### PR DESCRIPTION
Clicking a task group shows a tooltip with list of tasks. This tooltip
cannot be controlled by keyboard and it will stay open unless mouse is
used.

This patch changes the behavior so that when a global shortcut activates
a task group (usually Win+1, Win+2 etc.) a next task in the group is
activated without showing a tooltip.