### PR TITLE
Fix URL Type regarding KDE Bugtracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Announcements
 
 **Latte has moved its online services under kde infrastructure.**
 
-**New issues should be reported at:** https://bugs.kde.org/enter_bug.cgi?product=lattedock
+**New issues should be reported at:** https://bugs.kde.org/enter_bug.cgi?product=latte-dock
 
 **The codepage can be found at:** https://phabricator.kde.org/source/latte-dock/
 


### PR DESCRIPTION
the latte dock project seems to be at "https://bugs.kde.org/enter_bug.cgi?product=latte-dock", not "https://bugs.kde.org/enter_bug.cgi?product=lattedock" (note the dash).